### PR TITLE
Added 'reload_modules: True' in order to make Git available to the Salt ...

### DIFF
--- a/git/package.sls
+++ b/git/package.sls
@@ -3,3 +3,4 @@
 git:
   pkg.installed:
     - name: {{ git.get('git', 'git') }}
+    - reload_modules: True

--- a/git/source.sls
+++ b/git/source.sls
@@ -36,3 +36,4 @@ git:
       - cmd: get-git
     - require:
       - cmd: get-git
+    - reload_modules: True


### PR DESCRIPTION
...minion post-installation.  Otherwise, users of this formula must trigger a minion reload/refresh outside of the formula in order to preserve the idempotence of a highstate run that uses git states (i.e., one should not need to run multiple highstate jobs in order to converge upon the desired configuration).  