### PR TITLE
add Windows support

### DIFF
--- a/git/map.jinja
+++ b/git/map.jinja
@@ -20,4 +20,7 @@
     'FreeBSD': {
         'git': 'git',
     },
+    'Windows': {
+        'git': 'msysgit',
+    },
 }, merge=salt['pillar.get']('git:lookup')) %}


### PR DESCRIPTION
The *msysgit* package comes from the [Salt Windows Package Repository](https://github.com/saltstack/salt-winrepo).