### PR TITLE
Simplify configuration for official Ubuntu PPA

### DIFF
--- a/git/defaults.yaml
+++ b/git/defaults.yaml
@@ -2,6 +2,7 @@ git:
   git: git
   install_from_source: False
   install_pkgrepo: False
+  ubuntu_git_ppa: ppa:git-core/ppa
   source_install:
     remove_system_package: False
     version: 1.8.4.2

--- a/git/pkgrepo.sls
+++ b/git/pkgrepo.sls
@@ -3,12 +3,7 @@
 {%- if grains['os'] == 'Ubuntu' %}
 git_ppa_repo:
   pkgrepo.managed:
-    - humanname: git-ppa-{{ grains['oscodename'] }}
-    - name: deb http://ppa.launchpad.net/git-core/ppa/ubuntu {{ grains['oscodename'] }} main
-    - file: /etc/apt/sources.list.d/git-{{ grains['oscodename'] }}.list
-    - dist: {{ grains['oscodename'] }}
-    - keyid: E1DF1F24
-    - keyserver: keyserver.ubuntu.com
+    - name: {{ git_settings.ubuntu_git_ppa }}
 {%- if git_settings.install_pkgrepo %}
     - require_in:
       - pkg: git


### PR DESCRIPTION
No need to provide all of the settings under `pkgrepo.managed`.  Using `ppa:...` is sufficient.